### PR TITLE
Add space in block, to trigger Codacy auto-fix

### DIFF
--- a/src/main/java/com/thealgorithms/ciphers/DES.java
+++ b/src/main/java/com/thealgorithms/ciphers/DES.java
@@ -229,7 +229,7 @@ public class DES {
         }
         for (i = 0; i < l; i += 64) {
             String block = message.substring(i, i + 64);
-            String result = decryptBlock(block.toString(), subKeys);
+            String result = decryptBlock(block.toString() , subKeys);
             byte res[] = new byte[8];
             for (j = 0; j < 64; j += 8) {
                 res[j / 8] = (byte) Integer.parseInt(result.substring(j, j + 8), 2);


### PR DESCRIPTION
String result = decryptBlock(block.toString() , subKeys);

Codacy is already highlighting this as a performance issue, adding a space should add it to the commit, and auto-fix should trigger
